### PR TITLE
New device suggestion: Madimack Inverflow Pro variable speed water pump

### DIFF
--- a/custom_components/tuya_local/devices/madimack_inverflow_pro.yaml
+++ b/custom_components/tuya_local/devices/madimack_inverflow_pro.yaml
@@ -1,0 +1,176 @@
+name: Pool pump
+products:
+  - id: ircs2n82vgrozoew
+    name: Madimack Inverflow Pro P300i
+primary_entity:
+  entity: fan
+  dps:
+    - id: 105
+      type: boolean
+      name: switch
+    - id: 102
+      type: integer
+      name: speed
+      range:
+        min: 30
+        max: 120
+      readonly: true
+    - id: 116
+      name: unknown_116
+      type: string
+    - id: 117
+      name: unknown_117
+      type: string
+    - id: 115
+      name: unknown_115
+      type: boolean
+secondary_entities:
+  - entity: select
+    name: Pump mode
+    translation_key: mode
+    category: config
+    dps:
+      - id: 103
+        type: string
+        name: option
+        mapping:
+          - dps_val: "MI"
+            value: "Manual"
+          - dps_val: "AI"
+            value: "AI Flow set"
+          - dps_val: "backwash"
+            value: "Boost"
+  - entity: select
+    name: Pump flow units
+    translation_key: units
+    category: config
+    dps:
+      - id: 110
+        type: string
+        name: option
+        mapping:
+          - dps_val: "m3_h"
+            value: "m³/h"
+          - dps_val: "l_min"
+            value: "L/min"
+          - dps_val: "us_gpm"
+            value: "US gpm"
+          - dps_val: "ipm_gpm"
+            value: "International gpm"
+  - entity: number
+    name: Boost timer set
+    category: config
+    mode: box
+    dps:
+      - id: 104
+        type: integer
+        name: value
+        range:
+          min: 0
+          max: 1500
+        unit: sec
+  - entity: number
+    name: AI flow rate set
+    category: config
+    mode: slider
+    dps:
+      - id: 106
+        type: integer
+        name: value
+      - id: 101
+        type: integer
+        name: maximum
+      - id: 107
+        type: integer
+        name: minimum
+      - id: 113
+        type: integer
+        name: step
+      - id: 110
+        type: string
+        name: unit
+        mapping:
+          - dps_val: "m3_h"
+            value: "m³/h"
+          - dps_val: "l_min"
+            value: "L/min"
+          - dps_val: "us_gpm"
+            value: "gal/min"
+          - dps_val: "ipm_gpm"
+            value: "gal/min"
+  - entity: number
+    name: Manual percentage power set
+    category: config
+    mode: slider
+    dps:
+      - id: 111
+        type: integer
+        name: value
+        range:
+          min: 30
+          max: 120
+        unit: "%"
+  - entity: sensor
+    name: Boost time remaining
+    class: duration
+    category: diagnostic
+    dps:
+      - id: 108
+        type: integer
+        name: sensor
+        unit: sec
+  - entity: sensor
+    name: Current power
+    class: power
+    category: diagnostic
+    dps:
+      - id: 5
+        type: integer
+        name: sensor
+        unit: W
+  - entity: sensor
+    name: Flow rate
+    class: volume_flow_rate
+    category: diagnostic
+    dps:
+      - id: 112
+        type: integer
+        name: sensor
+      - id: 110
+        type: string
+        name: unit
+        mapping:
+          - dps_val: "m3_h"
+            value: "m³/h"
+          - dps_val: "l_min"
+            value: "L/min"
+          - dps_val: "us_gpm"
+            value: "gal/min"
+          - dps_val: "ipm_gpm"
+            value: "gal/min"
+  - entity: sensor
+    name: Hourly energy usage
+    class: energy
+    category: diagnostic
+    dps:
+      - id: 109
+        type: integer
+        name: sensor
+        class: measurement
+        unit: kWh
+        mapping:
+          - scale: 100
+  - entity: sensor
+    name: Fault code
+    category: diagnostic
+    dps:
+      - id: 2
+        type: bitfield
+        name: sensor
+  - entity: sensor
+    name: Flow pressure warning
+    category: diagnostic
+    dps:
+      - id: 114
+        type: boolean
+        name: sensor


### PR DESCRIPTION
This is a new device file for a variable speed pool water pump made by Madimack. The specific model here is called the Inverflow Pro P300i - there are a few other models in the range with more pump capacity. It is often paired with their pool heatpumps. They also have a range called Inverflow Ultra which may be compatible. Their Inverflow Eco range does not have wifi/Tuya control.

This pump has a rather obscure speed setting mechanism. There are three modes: a "boost" mode with a timer that sets the pump to 100% capacity, this is the default on startup, and the default timer is 180s. There is a "manual" mode that can set the pump from a range of 30-120%. There is also a flow based "AI" mode, that can set a pump flow rate in a variety of units. I have enabled all three modes as configurable variables, but not enumerated on the primary entity.

The primary entity I have configured as a fan (closest matching entity type in HA). The only operable aspect is the "on-off" functionality. I have added a speed DP as "read-only," which maps a read-only DP showing pump power as a range of 30-120%. This DP is the only one updated in Tuya regardless of the mode being used (manual, AI or boost). The "settable" control DP's for each of the modes otherwise act independently - i.e. if you set a speed in L/min, it does not update the %power writeable entity, and vice versa. If these control DP's are mapped to the primary fan entity, it can result in weird behaviour (i.e "speed" reads 100%, but pump is set via L/min to a lowest possible value).

There are also helpful diagnostic entity types: a boost timer countdown, current power reading, hourly reported energy use (mapped as "measurement" so it does not get added to the energy dashboard - a Riemann integral should be used instead), real flow rates and a flow pressure warning.

I have also added a select option for the flow units used by the unit. Although the DP is listed as writeable, trying to change the mode does not work on my unit (it resets back to L/min)

Because of the obscure control mechanism involving 3 modes, it is possible there is a more logical way of doing this. Let me know your feedback and I can modify. Other possible ideas I have include making the primary entity a switch only, making the speed reading a diagnostic entity. Or, using constraints to add a speed control that changes based on the mode of the pump